### PR TITLE
Remove incorrect copyright notices

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -1,15 +1,3 @@
-/*
- * IBM Confidential
- * OCO Source Materials
- * 5900-A1Y
- *
- * © Copyright IBM Corp. 2018, 2019
- *
- * The source code for this program is not published or
- * otherwise divested of its trade secrets, irrespective of
- * what has been deposited with the U.S. Copyright Office.
- */
-
 import * as express from 'express';
 import * as swaggerUi from 'swagger-ui-express';
 import * as http from 'http';

--- a/src/recall-assistant/controller.ts
+++ b/src/recall-assistant/controller.ts
@@ -1,15 +1,3 @@
-/*
- * IBM Confidential
- * OCO Source Materials
- * 5900-A1Y
- *
- * © Copyright IBM Corp. 2019
- *
- * The source code for this program is not published or
- * otherwise divested of its trade secrets, irrespective of
- * what has been deposited with the U.S. Copyright Office.
- */
-
 import * as express from 'express';
 import * as _ from 'lodash';
 

--- a/src/recall-assistant/ift-service.ts
+++ b/src/recall-assistant/ift-service.ts
@@ -1,15 +1,3 @@
-/*
- * IBM Confidential
- * OCO Source Materials
- * 5900-A1Y
- *
- * © Copyright IBM Corp. 2019
- *
- * The source code for this program is not published or
- * otherwise divested of its trade secrets, irrespective of
- * what has been deposited with the U.S. Copyright Office.
- */
-
 import { config } from '../app';
 import * as rp from 'request-promise-native';
 import * as _ from 'lodash';

--- a/src/recall-assistant/router.ts
+++ b/src/recall-assistant/router.ts
@@ -1,15 +1,3 @@
-/*
- * IBM Confidential
- * OCO Source Materials
- * 5900-A1Y
- *
- * © Copyright IBM Corp. 2019
- *
- * The source code for this program is not published or
- * otherwise divested of its trade secrets, irrespective of
- * what has been deposited with the U.S. Copyright Office.
- */
-
 import { Router } from 'express';
 import { getEpcsHandler,
          getEpcsWithTransformsHandler,

--- a/src/test/unit/recall-assistant/getTraceRestraintParameters.test.ts
+++ b/src/test/unit/recall-assistant/getTraceRestraintParameters.test.ts
@@ -1,15 +1,3 @@
-/*
- * IBM Confidential
- * OCO Source Materials
- * 5900-A1Y
- *
- * © Copyright IBM Corp. 2018
- *
- * The source code for this program is not published or
- * otherwise divested of its trade secrets, irrespective of
- * what has been deposited with the U.S. Copyright Office.
- */
-
 // Test Libraries
 import { expect } from 'chai';
 import { getTraceRestraintParameters } from '../../../recall-assistant/ift-service';


### PR DESCRIPTION
Copyright notices were in initial commit by me, but were added incorrectly by tooling and should not be in this code.  There is a copyright in the license file, but none of this is IBM IP.